### PR TITLE
Improve usability

### DIFF
--- a/i3_empty_workspace.sh
+++ b/i3_empty_workspace.sh
@@ -5,11 +5,11 @@ MAX_DESKTOPS=20
 WORKSPACES=$(seq -s '\n' 1 1 ${MAX_DESKTOPS})
 
 EMPTY_WORKSPACE=$( (i3-msg -t get_workspaces | tr ',' '\n' | grep num | awk -F:  '{print int($2)}' ; \
-            echo -e ${WORKSPACES} ) | sort -n | uniq -u | head -n 1)
+            echo -e ${WORKSPACES} ) | sed '/^-.*/d' | sort -n | uniq -u | head -n 1)
 
-CONFIG_FILE=$HOME/.i3/config
+CONFIG_FILE=$( i3 --more-version | grep -oP "Loaded i3 config: \K.*(?= \(Last modified)")
 if [ -f $CONFIG_FILE ]; then
-	grep "set \$w" $CONFIG_FILE
+	grep -q "set \$w" $CONFIG_FILE
 	if [ $? -eq 0 ]; then
 		NAMED_EMPTY_WORKSPACE=$(grep "set \$w" $CONFIG_FILE | grep $EMPTY_WORKSPACE | awk '{print $3,$4}')
 	else


### PR DESCRIPTION
I have made three changes to improve the usability of the script.
1. Support non-numeric workspace names.

Use sed to remove negative workspace numbers.

i3-msg workspace foo
[{"success":true}]

i3-msg -t get_workspaces
[{"num":1,"name":"1","visible":false,"focused":false,"rect":{"x":0,"y":0,"width":1680,"height":1029},"output":"DVI-D-1","urgent":false},{"num":39,"name":"39","visible":false,"focused":false,"rect":{"x":1680,"y":0,"width":1680,"height":1029},"output":"DVI-D-2","urgent":false},{"num":-1,"name":"foo","visible":false,"focused":false,"rect":{"x":1680,"y":0,"width":1680,"height":1029},"output":"DVI-D-2","urgent":false},{"num":9,"name":"9","visible":false,"focused":false,"rect":{"x":0,"y":0,"width":1680,"height":1029},"output":"DVI-D-1","urgent":false}]
1. Dynamically detect the location of the i3 config file.

See https://www.reddit.com/r/i3wm/comments/4pqyxc/is_there_an_i3_command_to_find_which_config_file/
1. Do not output the result of the grep against the config file.
